### PR TITLE
Added an errors file to track unknown phases

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ Bottie.Ears
     } else {
       speech.reply(message, 'Hmm... I couldn\'t tell what you said...');
       speech.reply(message, '```\n' + JSON.stringify(interpretation) + '\n```');
+
+      // append.write [message.text] ---> to a file
+      fs.appendFile('phrase-errors.txt', '\nChannel: ' + message.channel + ' User:'+ message.user + ' - ' + message.text, function (err) {
+        console.log('\n\tBrain Err: Appending phrase for review\n\t\t' + message.text + '\n');
+        });
     }
   });
 


### PR DESCRIPTION
Added an easy way to see which phrases were causing the bot to fail along with where / who was talking to the bot.  Makes it a bit easier to see what phrases could be added to the custom phrases JSON file.
